### PR TITLE
Fixing missing documentation issue on jdbcSqlStatus_T type

### DIFF
--- a/com.ibm.streamsx.jdbc/com.ibm.streamsx.jdbc.types/JDBCRunTypes.spl
+++ b/com.ibm.streamsx.jdbc/com.ibm.streamsx.jdbc.types/JDBCRunTypes.spl
@@ -5,7 +5,7 @@
 
 namespace com.ibm.streamsx.jdbc.types;
 
-/*
+/**
  * SQL Status
  * sqlCode: The error number associated with the SQLException, 0: successful
  * sqlState: The five-digit XOPEN SQLState code for a database error, 00000: Successful


### PR DESCRIPTION
Minor fix on missing documentation issue on jdbcSqlSstatus_T type to so that our automated build process will not generate warning 
