### PR TITLE
JDBC checkConnection 

### DIFF
--- a/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/AbstractJDBCOperator.java
+++ b/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/AbstractJDBCOperator.java
@@ -57,7 +57,7 @@ public abstract class AbstractJDBCOperator extends AbstractOperator implements S
 	protected static Logger TRACE = Logger.getLogger(PACKAGE_NAME);
 
 	/**
-	 * Define operator parameters
+	 * Define operator parameters 
 	 */
 	// This parameter specifies the path and the filename of jdbc driver libraries in one comma separated string).
 	private String jdbcDriverLib;
@@ -228,6 +228,8 @@ public abstract class AbstractJDBCOperator extends AbstractOperator implements S
 			return trustStorePassword;
 		}
 
+		
+		
 	/*
 	 * The method checkParametersRuntime
 	 */
@@ -236,6 +238,21 @@ public abstract class AbstractJDBCOperator extends AbstractOperator implements S
 
 		OperatorContext context = checker.getOperatorContext();
 
+		String strReconnectionPolicy = "";
+		if (context.getParameterNames().contains("reconnectionPolicy")) {
+			// reconnectionPolicy can be either InfiniteRetry, NoRetry,
+			// BoundedRetry
+			strReconnectionPolicy = context.getParameterValues("reconnectionPolicy").get(0).trim();
+			if (!(strReconnectionPolicy.equalsIgnoreCase(IJDBCConstants.RECONNPOLICY_NORETRY)
+					|| strReconnectionPolicy.equalsIgnoreCase(IJDBCConstants.RECONNPOLICY_BOUNDEDRETRY)
+				    || strReconnectionPolicy.equalsIgnoreCase(IJDBCConstants.RECONNPOLICY_INFINITERETRY))) {
+				LOGGER.log(LogLevel.ERROR, "reconnectionPolicy has to be set to InfiniteRetry or NoRetry or BoundedRetry");
+				checker.setInvalidContext("reconnectionPolicy has to be set to InfiniteRetry or NoRetry or BoundedRetry", new String[] { context.getParameterValues(
+						"reconnectionPolicy").get(0) });
+		
+			}
+		}
+		
 		// Check reconnection related parameters at runtime
 		if ((context.getParameterNames().contains("reconnectionBound"))) {
 			// reconnectionBound value should be non negative.
@@ -248,7 +265,7 @@ public abstract class AbstractJDBCOperator extends AbstractOperator implements S
 			if (context.getParameterNames().contains("reconnectionPolicy")) {
 				// reconnectionPolicy can be either InfiniteRetry, NoRetry,
 				// BoundedRetry
-				String strReconnectionPolicy = context.getParameterValues("reconnectionPolicy").get(0).trim();
+				 strReconnectionPolicy = context.getParameterValues("reconnectionPolicy").get(0).trim();
 				// reconnectionBound can appear only when the reconnectionPolicy
 				// parameter is set to BoundedRetry and cannot appear otherwise
 				if (! strReconnectionPolicy.equalsIgnoreCase(IJDBCConstants.RECONNPOLICY_BOUNDEDRETRY)) {
@@ -259,6 +276,7 @@ public abstract class AbstractJDBCOperator extends AbstractOperator implements S
 				}
 			}
 		}
+		
 
 	}
 

--- a/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCClientHelper.java
+++ b/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCClientHelper.java
@@ -65,6 +65,10 @@ public class JDBCClientHelper {
 	// The time period in seconds which it will be wait before trying to reconnect.
 	// If not specified, the default value is 10.0.
 	private double reconnectionInterval = IJDBCConstants.RECONN_INTERVAL_DEFAULT;
+	
+	//The time in seconds to wait for the database operation used to validate the connection to complete. 
+	private int checkConnectionTimeOut = 2;
+
 
 	// The statement
 	Statement stmt = null;
@@ -133,6 +137,7 @@ public class JDBCClientHelper {
 				// for each unsuccessful attempt increment the
 				// nConnectionAttempts
 				try {
+					DriverManager.setLoginTimeout(5);
 					nConnectionAttempts ++;
 					TRACE.log(TraceLevel.DEBUG,"JDBC connection attempt "+nConnectionAttempts);
 	    			if (jdbcConnectionProps != null){
@@ -207,7 +212,7 @@ public class JDBCClientHelper {
 	// Check if JDBC connection is valid
 	public synchronized boolean isValidConnection() throws SQLException{
 		LOGGER.log(LogLevel.INFO,"JDBC connection validation");
-		if (connection == null || !connection.isValid(0)){
+		if (connection == null || !connection.isValid(checkConnectionTimeOut)){
 			connected = false;
 			LOGGER.log(LogLevel.INFO,"JDBC connection invalid ");
 			return false;

--- a/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCClientHelper.java
+++ b/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCClientHelper.java
@@ -12,7 +12,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
-import java.util.Stack;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
@@ -151,16 +150,20 @@ public class JDBCClientHelper {
 					break;
 				} catch (SQLException e) {
 					// output excpetion info into trace file if in debug mode
-					TRACE.log(LogLevel.ERROR,"JDBC connect threw SQL Exception",e);
-					System.out.println("sqlCode: " + e.getErrorCode() + " sqlState: " + e.getSQLState() + " sqlMessage: " + e.getMessage());
-	    			// If Reconnection Policy is NoRetry, throw SQLException
-					if (reconnectionPolicy == IJDBCConstants.RECONNPOLICY_NORETRY) {
+					TRACE.log(LogLevel.ERROR,"JDBC connect threw SQL Exception",e);				
+					System.out.println("createConnection  SQLException  sqlCode: " + e.getErrorCode() + " sqlState: " + e.getSQLState() + " sqlMessage: " + e.getMessage());
+					System.out.println("createConnection  reconnectionPolicy: " + reconnectionPolicy);
+					System.out.println("createConnection  reconnectionBound: " + reconnectionBound);
+					System.out.println("createConnection  reconnectionInterval: " + reconnectionInterval);
+					System.out.println("createConnection  Connection Attempts: " + nConnectionAttempts);
+
+					// If Reconnection Policy is NoRetry, throw SQLException
+					if (reconnectionPolicy.equalsIgnoreCase(IJDBCConstants.RECONNPOLICY_NORETRY)) {
 						throw e;
 					}
 
 					// If Reconnection Policy is BoundedRetry, reconnect until maximum reconnectionBound value
-					if (reconnectionPolicy == IJDBCConstants.RECONNPOLICY_BOUNDEDRETRY) {
-						
+					if (reconnectionPolicy.equalsIgnoreCase(IJDBCConstants.RECONNPOLICY_BOUNDEDRETRY)) {
 						if (nConnectionAttempts == reconnectionBound){
 							//Throw SQLException if the connection attempts reach to maximum reconnectionBound value
 							throw e;
@@ -170,7 +173,7 @@ public class JDBCClientHelper {
 						}
 					}
 					// If Reconnection Policy is InfiniteRetry, reconnect
-					if (reconnectionPolicy == IJDBCConstants.RECONNPOLICY_INFINITERETRY) {
+					if (reconnectionPolicy.equalsIgnoreCase(IJDBCConstants.RECONNPOLICY_INFINITERETRY)) {
 						// Sleep for specified wait period
 						Thread.sleep(interval);
 					}
@@ -215,7 +218,7 @@ public class JDBCClientHelper {
 
 	// Return JDBC connection status
 	public boolean isConnected(){
-		return connected;
+ 		return connected;
 	}
 
 	// Reset the JDBC connection with the same configuration information

--- a/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
+++ b/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
@@ -240,7 +240,7 @@ public class JDBCRun extends AbstractJDBCOperator {
 		return checkConnection;
 	}
 	
-	
+	 
 	
 	/*
 	 * The method checkErrorOutputPort validates that the stream on error output

--- a/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
+++ b/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
@@ -5,6 +5,7 @@
 package com.ibm.streamsx.jdbc;
 
 import java.io.IOException;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -165,6 +166,7 @@ public class JDBCRun extends AbstractJDBCOperator {
 
 	
 	private Thread checkConnectionThread;
+	
 	
 	private CommitPolicy commitPolicy = DEFAULT_COMMIT_POLICY;
 
@@ -513,6 +515,14 @@ public class JDBCRun extends AbstractJDBCOperator {
 					}
 					
 					}
+				else
+				{
+					
+			        DatabaseMetaData metadata = jdbcClientHelper.getConnection().getMetaData();
+			        // Get database major  version for test
+			        int version = metadata.getDatabaseMajorVersion();
+			        System.out.println("Database Version:  " + version);
+				}
 				} catch (SQLException e3) {
 				}	
 			} // end while

--- a/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
+++ b/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
@@ -229,7 +229,7 @@ public class JDBCRun extends AbstractJDBCOperator {
 	}
 
 	// Parameter checkConnection
-	@Parameter(optional = true, description="This optional parameter specifies whether a **checkConnection** therad should be start. The default value is `ture`.")
+	@Parameter(optional = true, description="This optional parameter specifies whether a **checkConnection** therad should be start. The default value is `true`.")
 	public void setcheckConnection(boolean checkConnection) {
 		this.checkConnection = checkConnection;
 	}

--- a/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
+++ b/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
@@ -162,7 +162,7 @@ public class JDBCRun extends AbstractJDBCOperator {
 	// sqlStatus attribute for error output port
 	private String[] sqlStatusErrorAttrs = null;
 	// check connection
-	private boolean checkConnection = true;
+	private boolean checkConnection = false;
 
 	
 	private Thread checkConnectionThread;
@@ -231,7 +231,7 @@ public class JDBCRun extends AbstractJDBCOperator {
 	}
 
 	// Parameter checkConnection
-	@Parameter(optional = true, description="This optional parameter specifies whether a **checkConnection** therad should be start. The default value is `true`.")
+	@Parameter(optional = true, description="This optional parameter specifies whether a **checkConnection** therad should be start. The default value is `false`.")
 	public void setcheckConnection(boolean checkConnection) {
 		this.checkConnection = checkConnection;
 	}
@@ -515,14 +515,6 @@ public class JDBCRun extends AbstractJDBCOperator {
 					}
 					
 					}
-				else
-				{
-					
-			        DatabaseMetaData metadata = jdbcClientHelper.getConnection().getMetaData();
-			        // Get database major  version for test
-			        int version = metadata.getDatabaseMajorVersion();
-			        System.out.println("Database Version:  " + version);
-				}
 				} catch (SQLException e3) {
 				}	
 			} // end while

--- a/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
+++ b/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
@@ -231,7 +231,7 @@ public class JDBCRun extends AbstractJDBCOperator {
 	}
 
 	// Parameter checkConnection
-	@Parameter(optional = true, description="This optional parameter specifies whether a **checkConnection** therad should be start. The default value is `false`.")
+	@Parameter(optional = true, description="This optional parameter specifies whether a **checkConnection** therad should be start. The therad checks periodically the status of JDBC connection. The JDBCRun sends in case of any connection failure a SqlCode and a message to SPL application.The default value is `false`.")
 	public void setcheckConnection(boolean checkConnection) {
 		this.checkConnection = checkConnection;
 	}

--- a/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
+++ b/com.ibm.streamsx.jdbc/impl/java/src/com/ibm/streamsx/jdbc/JDBCRun.java
@@ -69,7 +69,7 @@ import com.ibm.streams.operator.types.XML;
 		+ " The SPL applications based on new JDBC toolkit and created with a new Streams that supports `optional type`"
 		+ " are able to write/read 'null' to/from a `nullable` column in a table. ")
 
-@InputPorts({
+@InputPorts({ 
 		@InputPortSet(cardinality = 1, description = "The `JDBCRun` operator has one required input port. When a tuple is received on the required input port, the operator runs an SQL statement."),
 		@InputPortSet(cardinality = 1, optional = true, controlPort = true, description = "The `JDBCRun` operator has one optional input port. This port allows operator to change jdbc connection information at run time.") })
 @OutputPorts({
@@ -160,7 +160,12 @@ public class JDBCRun extends AbstractJDBCOperator {
 	private String[] sqlStatusDataAttrs = null;
 	// sqlStatus attribute for error output port
 	private String[] sqlStatusErrorAttrs = null;
+	// check connection
+	private boolean checkConnection = true;
 
+	
+	private Thread checkConnectionThread;
+	
 	private CommitPolicy commitPolicy = DEFAULT_COMMIT_POLICY;
 
 	@Parameter(optional = true, description = "This parameter specifies the commit policy that should be used when the operator is in a consistent region. If set to *OnCheckpoint*, then commits will only occur during checkpointing. If set to *OnTransactionAndCheckpoint*, commits will occur during checkpointing as well as whenever the **transactionCount** or **commitInterval** are reached. The default value is *OnCheckpoint*. It is recommended that the *OnTransactionAndCheckpoint* value be set if the tables that the statements are being executed against can tolerate duplicate entries as these parameter value may cause the same statements to be executed if the operator is reset. It is also highly recommended that the **transactionCount** parameter not be set to a value greater than 1 when the policy is *onTransactionAndCheckpoint*, as this can lead to some statements not being executed in the event of a reset. This parameter is ignored if the operator is not in a consistent region. The default value for this parameter is *OnCheckpoint*.")
@@ -223,6 +228,18 @@ public class JDBCRun extends AbstractJDBCOperator {
 		this.commitInterval = commitInterval;
 	}
 
+	// Parameter checkConnection
+	@Parameter(optional = true, description="This optional parameter specifies whether a **checkConnection** therad should be start. The default value is `ture`.")
+	public void setcheckConnection(boolean checkConnection) {
+		this.checkConnection = checkConnection;
+	}
+
+	public boolean getCheckConnection() {
+		return checkConnection;
+	}
+	
+	
+	
 	/*
 	 * The method checkErrorOutputPort validates that the stream on error output
 	 * port contains the optional attribute of type which is the incoming tuple,
@@ -273,12 +290,14 @@ public class JDBCRun extends AbstractJDBCOperator {
 	 * 
 	 * @param checker
 	 */
+
 	@ContextCheck(compile = true)
 	public static void checkDeleteAll(OperatorContextChecker checker) {
 		if (!checker.checkDependentParameters("jdbcDriverLib", "jdbcUrl")){
 			checker.setInvalidContext(Messages.getString("JDBC_URL_NOT_EXIST"), null);
 		}
 	}
+	
 	@ContextCheck(compile = false, runtime = true)
 	public static void checkParameterAttributes(OperatorContextChecker checker) {
 
@@ -423,7 +442,12 @@ public class JDBCRun extends AbstractJDBCOperator {
 			hasErrorPort = true;
 			errorOutputPort = getOutput(1);
 		}
-
+		
+		
+		if (checkConnection) {
+			startCheckConnection(context);
+		}
+		
 		// set the data output port
 		dataOutputPort = getOutput(0);
 
@@ -431,13 +455,84 @@ public class JDBCRun extends AbstractJDBCOperator {
 		initSqlStatusAttr();
 
 		// Initiate PreparedStatement
-		initPreparedStatement();
-
+		initPreparedStatement();		
+	}			
+	
+	/**
+	 * startCheckConnection starts a thread to check the JDBC connection.
+	 * In case of any connection problem it tries to create a new connection
+	 * with reconnectionPolicy parameters.
+	 * When the connection fails it return a sqlcode -1 to the SPL application.
+	 * The SPL application has to use the 2. optional output port of JDBCRun operator.
+	 * @param context
+	 */
+	public void startCheckConnection(OperatorContext context) {
+		checkConnectionThread = context.getThreadFactory().newThread(new Runnable() {
+			
+		@Override
+		public void run() {
+			int i = 0;
+			while(true)
+			{
+				// check the JDBC connection every 5 seconds 
+				try        
+				{
+				    Thread.sleep(5000);
+                    System.out.println("checkConnection " + i++);
+				} 
+				catch(InterruptedException ex) 
+				{
+				    Thread.currentThread().interrupt();
+				}
+				try 
+				{
+				if (!jdbcClientHelper.isValidConnection()) {	
+                    System.out.println("JDBC connection is invalid ");					
+					try 
+					{
+						// f connection files it tries to reset JDBC connection
+						// it is depending to the reconnection policy parameters
+						resetJDBCConnection();
+					}
+					catch (Exception e2) {
+						if (!jdbcClientHelper.isValidConnection() && hasErrorPort){
+		                    try 
+							{
+								// if connection files it sends a sqlcode = -1 to the error output port
+		                        JDBCSqlStatus jSqlStatus = new JDBCSqlStatus();
+		                        jSqlStatus.sqlCode = -1;
+		                        jSqlStatus.sqlMessage = "Invalid Connection";
+								// submit error message
+								submitErrorTuple(errorOutputPort, null, jSqlStatus);
+							}
+							catch (Exception e1) {
+								e1.printStackTrace();													
+							}
+	                    
+						}   
+					}
+					
+					}
+				} catch (SQLException e3) {
+				}	
+			} // end while
+		} // end of run()
+		
+		}); 
+		
+		// start checkConnectionThread
+		checkConnectionThread.start();
 	}
 
-	// Process control port
-	// The port allows operator to change JDBC connection information at runtime
-	// The port expects a value with JSON format
+			
+	/**
+	 * Process control port
+	 * he port allows operator to change JDBC connection information at runtime
+	 * The port expects a value with JSON format
+	 * @param stream
+	 * @param tuple
+	 * @throws Exception
+	 */
 	@Override
 	protected void processControlPort(StreamingInput<Tuple> stream, Tuple tuple) throws Exception {
 		super.processControlPort(stream, tuple);
@@ -553,8 +648,14 @@ public class JDBCRun extends AbstractJDBCOperator {
 		}
 	}
 
-	
-		
+	/**
+	 * handleException
+	 * @param tuple
+	 * @param e
+	 * @throws Exception
+	 * @throws SQLException
+	 * @throws IOException
+	 */
 	private void handleException(Tuple tuple, SQLException e) throws Exception, SQLException, IOException {
 		JDBCSqlStatus jSqlStatus = new JDBCSqlStatus();
 		// System.out.println(" sqlCode: " + e.getErrorCode() + " sqlState: " + e.getSQLState() + " sqlMessage: " + e.getMessage());
@@ -960,7 +1061,10 @@ public class JDBCRun extends AbstractJDBCOperator {
 			commitThread.cancel(false);
 		}
 
-		// Roll back transaction & close connection
+		// stop checkConnectionThread
+		if (checkConnectionThread.isAlive()) {
+			checkConnectionThread.interrupt();
+		}
 		super.shutdown();
 
 	}
@@ -1020,6 +1124,10 @@ public class JDBCRun extends AbstractJDBCOperator {
 		}
 	}
 
+	/**
+	 * allPortsReady
+	 * @throws Exception
+	 */
 	@Override
 	public void allPortsReady() throws Exception {
 		if ((consistentRegionContext == null 
@@ -1049,13 +1157,10 @@ public class JDBCRun extends AbstractJDBCOperator {
 						try {
 							handleException(null, e);
 						} catch (SQLException e1) {
-							// TODO Auto-generated catch block
 							e1.printStackTrace();
 						} catch (IOException e1) {
-							// TODO Auto-generated catch block
 							e1.printStackTrace();
 						} catch (Exception e1) {
-							// TODO Auto-generated catch block
 							e1.printStackTrace();
 						} finally {
 							commitLock.unlock();

--- a/com.ibm.streamsx.jdbc/info.xml
+++ b/com.ibm.streamsx.jdbc/info.xml
@@ -6,7 +6,7 @@
     
   The statement is run once for each input tuple received. Result sets that are produced by the statement are emitted as output stream tuples. 
     
-  The JDBCRun operator is commonly used to update, merge, and delete database management system (DBMS) records. 
+  The **JDBCRun** operator is commonly used to update, merge, and delete database management system (DBMS) records. 
   
   This operator is also used to retrieve records, create and drop tables, and to call stored procedures. 
 
@@ -25,6 +25,8 @@
   The JDBCRun operator support **optional type** feature.
 
   It supports also **phoenix jdbc** to connect to the HBASE database.
+  
+  The **JDBCRun** operator has been improved in version 1.4.0 with a new parameter **checkConnection**. This optional parameter specifies whether a **checkConnection** thread should be start. It checks periodically the status of JDBC connection. The JDBCRun sends in case of any failure a SqlCode and a message to SPL application.
   
 
 </info:description>

--- a/com.ibm.streamsx.jdbc/info.xml
+++ b/com.ibm.streamsx.jdbc/info.xml
@@ -28,8 +28,8 @@
   
 
 </info:description>
-    <info:version>1.3.0</info:version>
-    <info:requiredProductVersion>4.1.0.0</info:requiredProductVersion>
+    <info:version>1.4.0</info:version>
+    <info:requiredProductVersion>4.2.0.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies/>
 </info:toolkitInfoModel>

--- a/samples/JDBCSample/toolkit.xml
+++ b/samples/JDBCSample/toolkit.xml
@@ -4,20 +4,20 @@
   <toolkit name="JDBCSample" requiredProductVersion="4.2.1.0" version="1.0.0">
     <description>JDBCSample</description>
     <uriTable>
+      <uri index="1" value="com.ibm.streamsx.jdbc.sample.jdbcrun/JDBCReconnection.spl"/>
       <uri index="2" value="com.ibm.streamsx.jdbc.sample.jdbcrun/JDBCRunErrorPort.spl"/>
-      <uri index="1" value="com.ibm.streamsx.jdbc.sample.jdbcrun/JDBCRunSample.spl"/>
+      <uri index="3" value="com.ibm.streamsx.jdbc.sample.jdbcrun/JDBCRunSample.spl"/>
     </uriTable>
     <namespace name="com.ibm.streamsx.jdbc.sample.jdbcrun">
-      <compositeOp column="11" line="24" name="JDBCRunSample" potentialMain="true" uriIndex="1">
+      <compositeOp column="11" line="32" name="JDBCReconnection" potentialMain="true" uriIndex="1">
         <description>*****************************************************************************</description>
         <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcDriverLib&quot;, &quot;opt/db2jcc4.jar&quot;)" metaType="Expression" name="jdbcDriverLib" optional="true" type="&lt;rstring>"/>
         <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcClassName&quot;, &quot;com.ibm.db2.jcc.DB2Driver&quot;)" metaType="Expression" name="jdbcClassName" optional="true" type="&lt;rstring>"/>
-        <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcUrl&quot;, &quot;jdbc:db2://&lt;your-db2-server>/&lt;your-db2-db-name>&quot;)" metaType="Expression" name="jdbcUrl" optional="true" type="&lt;rstring>"/>
-        <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcUser&quot;, &quot;&lt;your-db2-user>&quot;)" metaType="Expression" name="jdbcUser" optional="true" type="&lt;rstring>"/>
-        <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcPassword&quot;, &quot;your-db2-password&quot;)" metaType="Expression" name="jdbcPassword" optional="true" type="&lt;rstring>"/>
-        <type column="3" line="35" name="insertSchema" type="int32 ID, rstring FNAME, rstring LNAME, int32 AGE, rstring GENDER, float32 SCORE, float64 TOTAL" uriIndex="1"/>
-        <type column="3" line="42" name="rsSchema" type="int32 ID, rstring FNAME, rstring LNAME, int32 AGE, rstring GENDER, float32 SCORE, float64 TOTAL" uriIndex="1"/>
-        <type column="3" line="49" name="selectSchema" type="rstring sql" uriIndex="1"/>
+        <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcUrl&quot;, &quot;jdbc:db2://&lt;your-db2-server-name>:50000/&lt;your-db-name>:retrieveMessagesFromServerOnGetMessage=true;&quot;)" metaType="Expression" name="jdbcUrl" optional="true" type="&lt;rstring>"/>
+        <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcUser&quot;, &quot;&lt;yourdb2-user>&quot;)" metaType="Expression" name="jdbcUser" optional="true" type="&lt;rstring>"/>
+        <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcPassword&quot;, &quot;&lt;yourdb2-password&quot;)" metaType="Expression" name="jdbcPassword" optional="true" type="&lt;rstring>"/>
+        <type column="3" line="43" name="rsSchema" type="int32 ID, rstring NAME" uriIndex="1"/>
+        <type column="3" line="44" name="selectSchema" type="rstring sql" uriIndex="1"/>
       </compositeOp>
       <compositeOp column="11" line="14" name="JDBCRunErrorPort" potentialMain="true" uriIndex="2">
         <description>*****************************************************************************</description>
@@ -29,6 +29,17 @@
         <type column="3" line="25" name="insertSchema" type="int32 ID, rstring NAME" uriIndex="2"/>
         <type column="3" line="26" name="rsSchema" type="int32 ID, rstring NAME" uriIndex="2"/>
         <type column="3" line="27" name="selectSchema" type="rstring sql" uriIndex="2"/>
+      </compositeOp>
+      <compositeOp column="11" line="24" name="JDBCRunSample" potentialMain="true" uriIndex="3">
+        <description>*****************************************************************************</description>
+        <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcDriverLib&quot;, &quot;opt/db2jcc4.jar&quot;)" metaType="Expression" name="jdbcDriverLib" optional="true" type="&lt;rstring>"/>
+        <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcClassName&quot;, &quot;com.ibm.db2.jcc.DB2Driver&quot;)" metaType="Expression" name="jdbcClassName" optional="true" type="&lt;rstring>"/>
+        <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcUrl&quot;, &quot;jdbc:db2://&lt;your-db2-server>/&lt;your-db2-db-name>&quot;)" metaType="Expression" name="jdbcUrl" optional="true" type="&lt;rstring>"/>
+        <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcUser&quot;, &quot;&lt;your-db2-user>&quot;)" metaType="Expression" name="jdbcUser" optional="true" type="&lt;rstring>"/>
+        <parameter defaultValue="getSubmissionTimeValue(&quot;jdbcPassword&quot;, &quot;your-db2-password&quot;)" metaType="Expression" name="jdbcPassword" optional="true" type="&lt;rstring>"/>
+        <type column="3" line="35" name="insertSchema" type="int32 ID, rstring FNAME, rstring LNAME, int32 AGE, rstring GENDER, float32 SCORE, float64 TOTAL" uriIndex="3"/>
+        <type column="3" line="42" name="rsSchema" type="int32 ID, rstring FNAME, rstring LNAME, int32 AGE, rstring GENDER, float32 SCORE, float64 TOTAL" uriIndex="3"/>
+        <type column="3" line="49" name="selectSchema" type="rstring sql" uriIndex="3"/>
       </compositeOp>
     </namespace>
     <sabFiles>


### PR DESCRIPTION
Corrections for check JDBC connection #69 have been checked in develop branch.
The JDBCRun operator has been improved with a new parameter  **checkConnection**.
This optional parameter specifies whether a **checkConnection** therad should be start. The default value is "true". 
In case of any JDBC connection problem, it tries to create a new connection depending to the recontention policy parameter.
If it is not possible to setup a new JDBC connection it sends a sqlcode = -1 via error output port to SPL application.
The SPL application can handles this code. 
For example stop the PEs or check the logos i SPL application. 
	